### PR TITLE
FieldLabel added to DextopFormContainer

### DIFF
--- a/Libraries/Codaxy.Dextop/Codaxy.Dextop/Forms/DextopForm.Attributes.Checkbox.cs
+++ b/Libraries/Codaxy.Dextop/Codaxy.Dextop/Forms/DextopForm.Attributes.Checkbox.cs
@@ -6,85 +6,78 @@ using Codaxy.Dextop.Tools;
 
 namespace Codaxy.Dextop.Forms
 {
-	/// <summary>
-	/// Ext.form.CheckboxField
-	/// </summary>
-	public class DextopFormCheckboxAttribute : DextopFormFieldAttribute
-	{
-		/// <summary>
-		/// Ext.form.CheckboxField
-		/// </summary>
-		public DextopFormCheckboxAttribute()
-			: base()
-		{
-			xtype = "checkboxfield";
+    /// <summary>
+    /// Ext.form.CheckboxField
+    /// </summary>
+    public class DextopFormCheckboxAttribute : DextopFormFieldAttribute
+    {
+        /// <summary>
+        /// Ext.form.CheckboxField
+        /// </summary>
+        public DextopFormCheckboxAttribute()
+            : base()
+        {
+            xtype = "checkboxfield";
             hideEmptyLabel = false;
-		}
-	}
+        }
+    }
 
-	/// <summary>
-	/// Ext.form.CheckboxGroup (xtype: checkboxgroup)
-	/// </summary>
-	public class DextopFormCheckboxGroupAttribute : DextopFormContainerAttribute
-	{
-		/// <summary>
-		/// Ext.form.CheckboxGroup (xtype: checkboxgroup)
-		/// </summary>
-		public DextopFormCheckboxGroupAttribute(int level)
-			: base(level)
-		{
-			xtype = "checkboxgroup";
-			allowBlank = true;
-		}
+    /// <summary>
+    /// Ext.form.CheckboxGroup (xtype: checkboxgroup)
+    /// </summary>
+    public class DextopFormCheckboxGroupAttribute : DextopFormContainerAttribute
+    {
+        /// <summary>
+        /// Ext.form.CheckboxGroup (xtype: checkboxgroup)
+        /// </summary>
+        public DextopFormCheckboxGroupAttribute(int level)
+            : base(level)
+        {
+            xtype = "checkboxgroup";
+            allowBlank = true;
+        }
 
-		/// <summary>
-		/// Converts this attribute to a Dextop container.
-		/// </summary>
-		/// <param name="memberName">Name of the member.</param>
-		/// <param name="memberType">Type of the member.</param>
-		/// <returns></returns>
-		public override DextopFormContainer ToContainer(string memberName, Type memberType)
-		{
-			DextopFormContainer container = base.ToContainer(memberName, memberType);
-			if (!allowBlank)
-				container["allowBlank"] = allowBlank;
-			if (vertical)
-				container["vertical"] = vertical;
-			if (columns > 0)
-				container["columns"] = columns;
-			else if (columnWidths != null)
-				container["columns"] = columnWidths;
-			if (fieldLabel != null)
-				container["fieldLabel"] = fieldLabel;
-			return container;
-		}
+        /// <summary>
+        /// Converts this attribute to a Dextop container.
+        /// </summary>
+        /// <param name="memberName">Name of the member.</param>
+        /// <param name="memberType">Type of the member.</param>
+        /// <returns></returns>
+        public override DextopFormContainer ToContainer(string memberName, Type memberType)
+        {
+            DextopFormContainer container = base.ToContainer(memberName, memberType);
+            if (!allowBlank)
+                container["allowBlank"] = allowBlank;
+            if (vertical)
+                container["vertical"] = vertical;
+            if (columns > 0)
+                container["columns"] = columns;
+            else if (columnWidths != null)
+                container["columns"] = columnWidths;
+            return container;
+        }
 
-		/// <summary>
-		/// False to validate that at least one item in the group is checked
-		/// (defaults to true). 
-		/// </summary>
-		public bool allowBlank { get; set; }
+        /// <summary>
+        /// False to validate that at least one item in the group is checked
+        /// (defaults to true). 
+        /// </summary>
+        public bool allowBlank { get; set; }
 
-		/// <summary>
-		/// True to distribute contained controls across columns, 
-		/// completely filling each column top to bottom before starting on.
-		/// </summary>
-		public bool vertical { get; set; }
-		
-		/// <summary>
-		/// Leave empty to and controls will be rendered one per column on one row and the width of each column will be evenly distributed based on the width of the overall field container.
-		/// If you specify the number (e.g., 3) that number of columns will be created and the contained controls will be automatically distributed based on the value of vertical.
-		/// </summary>
-		public int columns { get; set; }
+        /// <summary>
+        /// True to distribute contained controls across columns, 
+        /// completely filling each column top to bottom before starting on.
+        /// </summary>
+        public bool vertical { get; set; }
 
-		/// <summary>
-		/// Specify an array of column widths, mixing integer (fixed width) and float (percentage width) values as needed (e.g., [100, .25, .75]). Any integer values will be rendered first, then any float values will be calculated as a percentage of the remaining space. Float values do not have to add up to 1 (100%) although if you want the controls to take up the entire field container you should do so.
-		/// </summary>
-		public double[] columnWidths { get; set; }
+        /// <summary>
+        /// Leave empty to and controls will be rendered one per column on one row and the width of each column will be evenly distributed based on the width of the overall field container.
+        /// If you specify the number (e.g., 3) that number of columns will be created and the contained controls will be automatically distributed based on the value of vertical.
+        /// </summary>
+        public int columns { get; set; }
 
-		/// <summary>
-		/// Gets or sets the field label.
-		/// </summary>		
-		public string fieldLabel { get; set; }
-	}
+        /// <summary>
+        /// Specify an array of column widths, mixing integer (fixed width) and float (percentage width) values as needed (e.g., [100, .25, .75]). Any integer values will be rendered first, then any float values will be calculated as a percentage of the remaining space. Float values do not have to add up to 1 (100%) although if you want the controls to take up the entire field container you should do so.
+        /// </summary>
+        public double[] columnWidths { get; set; }
+    }
 }

--- a/Libraries/Codaxy.Dextop/Codaxy.Dextop/Forms/DextopForm.Attributes.Container.cs
+++ b/Libraries/Codaxy.Dextop/Codaxy.Dextop/Forms/DextopForm.Attributes.Container.cs
@@ -6,85 +6,91 @@ using Codaxy.Dextop.Tools;
 
 namespace Codaxy.Dextop.Forms
 {
-	/// <summary>
-	/// Ext Container
-	/// </summary>
-	[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
-	public class DextopFormContainerAttribute : System.Attribute
-	{
+    /// <summary>
+    /// Ext Container
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]
+    public class DextopFormContainerAttribute : System.Attribute
+    {
 
-		/// <summary>
-		/// Ext Container
-		/// </summary>
-		public DextopFormContainerAttribute()
-		{			
-			border = true;
-		}
+        /// <summary>
+        /// Ext Container
+        /// </summary>
+        public DextopFormContainerAttribute()
+        {
+            border = true;
+        }
 
-		/// <summary>
-		/// Ext Container
-		/// </summary>
-		/// <param name="level">The level.</param>
-		public DextopFormContainerAttribute(int level) : this() { Level = level; }
+        /// <summary>
+        /// Ext Container
+        /// </summary>
+        /// <param name="level">The level.</param>
+        public DextopFormContainerAttribute(int level) : this() { Level = level; }
 
-		/// <summary>
-		/// Gets or sets the level. Use level to define a tree of items. All items with higher level belong to the first container of lower level.
-		/// </summary>		
-		public int Level { get; set; }
-		/// <summary>
-		/// 
-		/// </summary>
-		public String title { get; set; }
+        /// <summary>
+        /// Gets or sets the level. Use level to define a tree of items. All items with higher level belong to the first container of lower level.
+        /// </summary>		
+        public int Level { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public String xtype { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public String title { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public string itemId { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public String fieldLabel { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public string layout { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public String xtype { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public string margins { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string itemId { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public string fieldDefaults { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string layout { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public string defaults { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string margin { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public string style { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string fieldDefaults { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public string bodyStyle { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string defaults { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public bool border { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string style { get; set; }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		public bool autoHeight { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string bodyStyle { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool border { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool autoHeight { get; set; }
 
         /// <summary>
         /// List of items to be prepended to the items property. Note that items have to defined on the client side.
@@ -121,21 +127,22 @@ namespace Codaxy.Dextop.Forms
         /// </summary>
         public int width { get; set; }
 
-		/// <summary>
-		/// Converts this attribute to a Dextop container.
-		/// </summary>
-		/// <param name="memberName">Name of the member.</param>
-		/// <param name="memberType">Type of the member.</param>		
-		/// <returns></returns>
-		public virtual DextopFormContainer ToContainer(String memberName, Type memberType)
-		{
+        /// <summary>
+        /// Converts this attribute to a Dextop container.
+        /// </summary>
+        /// <param name="memberName">Name of the member.</param>
+        /// <param name="memberType">Type of the member.</param>		
+        /// <returns></returns>
+        public virtual DextopFormContainer ToContainer(String memberName, Type memberType)
+        {
             var res = new DextopFormContainer
             {
                 xtype = xtype,
                 itemId = itemId,
                 title = title,
+                fieldLabel = fieldLabel,
                 layout = layout,
-                margins = margins,
+                margin = margin,
                 fieldDefaults = fieldDefaults,
                 defaults = defaults,
                 Level = Level,
@@ -152,209 +159,209 @@ namespace Codaxy.Dextop.Forms
                 width = NullableUtil.DefaultNull(width, 0),
 
             };
-			if (this is IDextopFormLabelable)
-				res.ApplyLabelable((IDextopFormLabelable)this);
-			return res;
-		}
-	}
+            if (this is IDextopFormLabelable)
+                res.ApplyLabelable((IDextopFormLabelable)this);
+            return res;
+        }
+    }
 
-	/// <summary>
-	/// Ext.form.FieldContainer (xtype: fieldcontainer)
-	/// </summary>
-	public class DextopFormFieldContainerAttribute : DextopFormContainerAttribute, IDextopFormLabelable
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="DextopFormFieldContainerAttribute"/> class.
-		/// </summary>
-		public DextopFormFieldContainerAttribute() { xtype = "fieldcontainer"; }
-		/// <summary>
-		/// Initializes a new instance of the <see cref="DextopFormFieldContainerAttribute"/> class.
-		/// </summary>
-		/// <param name="level">The level.</param>
-		public DextopFormFieldContainerAttribute(int level) : this() { Level = level; }		
+    /// <summary>
+    /// Ext.form.FieldContainer (xtype: fieldcontainer)
+    /// </summary>
+    public class DextopFormFieldContainerAttribute : DextopFormContainerAttribute, IDextopFormLabelable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DextopFormFieldContainerAttribute"/> class.
+        /// </summary>
+        public DextopFormFieldContainerAttribute() { xtype = "fieldcontainer"; }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DextopFormFieldContainerAttribute"/> class.
+        /// </summary>
+        /// <param name="level">The level.</param>
+        public DextopFormFieldContainerAttribute(int level) : this() { Level = level; }
 
-		/// <summary>
-		/// Set to true to completely hide the label element (fieldLabel and labelSeparator).
-		/// </summary>
-		public bool hideLabel { get; set; }
+        /// <summary>
+        /// Set to true to completely hide the label element (fieldLabel and labelSeparator).
+        /// </summary>
+        public bool hideLabel { get; set; }
 
-		/// <summary>
-		/// When set to true, the label element (fieldLabel and labelSeparator) will be automatically hidden if the fieldLabel is empty. Setting this to false will cause the empty label element to be rendered and space to be reserved for it; this is useful if you want a field without a label to line up with other labeled fields in the same form.
-		/// </summary>
-		public bool hideEmptyLabel { get; set; }
+        /// <summary>
+        /// When set to true, the label element (fieldLabel and labelSeparator) will be automatically hidden if the fieldLabel is empty. Setting this to false will cause the empty label element to be rendered and space to be reserved for it; this is useful if you want a field without a label to line up with other labeled fields in the same form.
+        /// </summary>
+        public bool hideEmptyLabel { get; set; }
 
-		/// <summary>
-		/// The label for the field. It gets appended with the labelSeparator, and its position and sizing is determined by the labelAlign, labelWidth, and labelPad configs.
-		/// </summary>
-		public string fieldLabel { get; set; }
+        /// <summary>
+        /// The label for the field. It gets appended with the labelSeparator, and its position and sizing is determined by the labelAlign, labelWidth, and labelPad configs.
+        /// </summary>
+        public string fieldLabel { get; set; }
 
-		/// <summary>
-		/// The CSS class to use when marking the component invalid (defaults to 'x-form-invalid')
-		/// </summary>
-		public string invalidCls { get; set; }
+        /// <summary>
+        /// The CSS class to use when marking the component invalid (defaults to 'x-form-invalid')
+        /// </summary>
+        public string invalidCls { get; set; }
 
-		/// <summary>
-		/// Controls the position and alignment of the fieldLabel. Valid values are:
-		/// - "left" (the default) - The label is positioned to the left of the field, with its text aligned to the left. Its width is determined by the labelWidth config.
-		/// - "top" - The label is positioned above the field.
-		/// - "right" - The label is positioned to the left of the field, with its text aligned to the right. Its width is determined by the labelWidth config.
-		/// </summary>
-		public string labelAlign { get; set; }
+        /// <summary>
+        /// Controls the position and alignment of the fieldLabel. Valid values are:
+        /// - "left" (the default) - The label is positioned to the left of the field, with its text aligned to the left. Its width is determined by the labelWidth config.
+        /// - "top" - The label is positioned above the field.
+        /// - "right" - The label is positioned to the left of the field, with its text aligned to the right. Its width is determined by the labelWidth config.
+        /// </summary>
+        public string labelAlign { get; set; }
 
-		/// <summary>
-		/// The CSS class to be applied to the label element. Defaults to 'x-form-item-label'.
-		/// </summary>
-		public string labelCls { get; set; }
+        /// <summary>
+        /// The CSS class to be applied to the label element. Defaults to 'x-form-item-label'.
+        /// </summary>
+        public string labelCls { get; set; }
 
-		/// <summary>
-		/// The amount of space in pixels between the fieldLabel and the input field. Defaults to 5.
-		/// </summary>
-		public int labelPad { get; set; }
+        /// <summary>
+        /// The amount of space in pixels between the fieldLabel and the input field. Defaults to 5.
+        /// </summary>
+        public int labelPad { get; set; }
 
-		/// <summary>
-		/// Character(s) to be inserted at the end of the label text.
-		/// </summary>
-		public string labelSeparator { get; set; }
+        /// <summary>
+        /// Character(s) to be inserted at the end of the label text.
+        /// </summary>
+        public string labelSeparator { get; set; }
 
-		/// <summary>
-		/// A CSS style specification string to apply directly to this field's label.
-		/// </summary>
-		public string labelStyle { get; set; }
+        /// <summary>
+        /// A CSS style specification string to apply directly to this field's label.
+        /// </summary>
+        public string labelStyle { get; set; }
 
-		/// <summary>
-		/// The width of the fieldLabel in pixels. Only applicable if the labelAlign is set to "left" or "right". Defaults to 100.
-		/// </summary>
-		public int labelWidth { get; set; }
+        /// <summary>
+        /// The width of the fieldLabel in pixels. Only applicable if the labelAlign is set to "left" or "right". Defaults to 100.
+        /// </summary>
+        public int labelWidth { get; set; }
 
-		/// <summary>
-		/// The location where the error message text should display. Must be one of the following values:
-		/// - qtip - Display a quick tip containing the message when the user hovers over the field. This is the default.
-		/// Ext.tip.QuickTipManager.init must have been called for this setting to work.
-		/// - title - Display the message in a default browser title attribute popup.
-		/// under Add a block div beneath the field containing the error message.
-		/// - side - Add an error icon to the right of the field, displaying the message in a popup on hover.
-		/// - none - Don't display any error message. This might be useful if you are implementing custom error display.
-		/// - [element id] - Add the error message directly to the innerHTML of the specified element.
-		/// </summary>
-		public string msgTarget { get; set; }
+        /// <summary>
+        /// The location where the error message text should display. Must be one of the following values:
+        /// - qtip - Display a quick tip containing the message when the user hovers over the field. This is the default.
+        /// Ext.tip.QuickTipManager.init must have been called for this setting to work.
+        /// - title - Display the message in a default browser title attribute popup.
+        /// under Add a block div beneath the field containing the error message.
+        /// - side - Add an error icon to the right of the field, displaying the message in a popup on hover.
+        /// - none - Don't display any error message. This might be useful if you are implementing custom error display.
+        /// - [element id] - Add the error message directly to the innerHTML of the specified element.
+        /// </summary>
+        public string msgTarget { get; set; }
 
-		/// <summary>
-		/// /// true to disable displaying any error message set on this object. Defaults to false.
-		/// </summary>		
-		public bool preventMark { get; set; }
-	}
+        /// <summary>
+        /// /// true to disable displaying any error message set on this object. Defaults to false.
+        /// </summary>		
+        public bool preventMark { get; set; }
+    }
 
-	/// <summary>
-	/// Ext.panel.Panel
-	/// </summary>
-	public class DextopFormPanelAttribute : DextopFormContainerAttribute, IDextopFormLabelable
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="DextopFormPanelAttribute"/> class.
-		/// </summary>
-		public DextopFormPanelAttribute() { xtype = "panel"; }
-		/// <summary>
-		/// Initializes a new instance of the <see cref="DextopFormPanelAttribute"/> class.
-		/// </summary>
-		/// <param name="level">The level.</param>
-		public DextopFormPanelAttribute(int level) : this() { Level = level; }
+    /// <summary>
+    /// Ext.panel.Panel
+    /// </summary>
+    public class DextopFormPanelAttribute : DextopFormContainerAttribute, IDextopFormLabelable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DextopFormPanelAttribute"/> class.
+        /// </summary>
+        public DextopFormPanelAttribute() { xtype = "panel"; }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DextopFormPanelAttribute"/> class.
+        /// </summary>
+        /// <param name="level">The level.</param>
+        public DextopFormPanelAttribute(int level) : this() { Level = level; }
 
-		/// <summary>
-		/// Set to true to completely hide the label element (fieldLabel and labelSeparator).
-		/// </summary>
-		public bool hideLabel { get; set; }
+        /// <summary>
+        /// Set to true to completely hide the label element (fieldLabel and labelSeparator).
+        /// </summary>
+        public bool hideLabel { get; set; }
 
-		/// <summary>
-		/// When set to true, the label element (fieldLabel and labelSeparator) will be automatically hidden if the fieldLabel is empty. Setting this to false will cause the empty label element to be rendered and space to be reserved for it; this is useful if you want a field without a label to line up with other labeled fields in the same form.
-		/// </summary>
-		public bool hideEmptyLabel { get; set; }
+        /// <summary>
+        /// When set to true, the label element (fieldLabel and labelSeparator) will be automatically hidden if the fieldLabel is empty. Setting this to false will cause the empty label element to be rendered and space to be reserved for it; this is useful if you want a field without a label to line up with other labeled fields in the same form.
+        /// </summary>
+        public bool hideEmptyLabel { get; set; }
 
-		/// <summary>
-		/// The label for the field. It gets appended with the labelSeparator, and its position and sizing is determined by the labelAlign, labelWidth, and labelPad configs.
-		/// </summary>
-		public string fieldLabel { get; set; }
+        /// <summary>
+        /// The label for the field. It gets appended with the labelSeparator, and its position and sizing is determined by the labelAlign, labelWidth, and labelPad configs.
+        /// </summary>
+        public string fieldLabel { get; set; }
 
-		/// <summary>
-		/// The CSS class to use when marking the component invalid (defaults to 'x-form-invalid')
-		/// </summary>
-		public string invalidCls { get; set; }
+        /// <summary>
+        /// The CSS class to use when marking the component invalid (defaults to 'x-form-invalid')
+        /// </summary>
+        public string invalidCls { get; set; }
 
-		/// <summary>
-		/// Controls the position and alignment of the fieldLabel. Valid values are:
-		/// - "left" (the default) - The label is positioned to the left of the field, with its text aligned to the left. Its width is determined by the labelWidth config.
-		/// - "top" - The label is positioned above the field.
-		/// - "right" - The label is positioned to the left of the field, with its text aligned to the right. Its width is determined by the labelWidth config.
-		/// </summary>
-		public string labelAlign { get; set; }
+        /// <summary>
+        /// Controls the position and alignment of the fieldLabel. Valid values are:
+        /// - "left" (the default) - The label is positioned to the left of the field, with its text aligned to the left. Its width is determined by the labelWidth config.
+        /// - "top" - The label is positioned above the field.
+        /// - "right" - The label is positioned to the left of the field, with its text aligned to the right. Its width is determined by the labelWidth config.
+        /// </summary>
+        public string labelAlign { get; set; }
 
-		/// <summary>
-		/// The CSS class to be applied to the label element. Defaults to 'x-form-item-label'.
-		/// </summary>
-		public string labelCls { get; set; }
+        /// <summary>
+        /// The CSS class to be applied to the label element. Defaults to 'x-form-item-label'.
+        /// </summary>
+        public string labelCls { get; set; }
 
-		/// <summary>
-		/// The amount of space in pixels between the fieldLabel and the input field. Defaults to 5.
-		/// </summary>
-		public int labelPad { get; set; }
+        /// <summary>
+        /// The amount of space in pixels between the fieldLabel and the input field. Defaults to 5.
+        /// </summary>
+        public int labelPad { get; set; }
 
-		/// <summary>
-		/// Character(s) to be inserted at the end of the label text.
-		/// </summary>
-		public string labelSeparator { get; set; }
+        /// <summary>
+        /// Character(s) to be inserted at the end of the label text.
+        /// </summary>
+        public string labelSeparator { get; set; }
 
-		/// <summary>
-		/// A CSS style specification string to apply directly to this field's label.
-		/// </summary>
-		public string labelStyle { get; set; }
+        /// <summary>
+        /// A CSS style specification string to apply directly to this field's label.
+        /// </summary>
+        public string labelStyle { get; set; }
 
-		/// <summary>
-		/// The width of the fieldLabel in pixels. Only applicable if the labelAlign is set to "left" or "right". Defaults to 100.
-		/// </summary>
-		public int labelWidth { get; set; }
+        /// <summary>
+        /// The width of the fieldLabel in pixels. Only applicable if the labelAlign is set to "left" or "right". Defaults to 100.
+        /// </summary>
+        public int labelWidth { get; set; }
 
-		/// <summary>
-		/// The location where the error message text should display. Must be one of the following values:
-		/// - qtip - Display a quick tip containing the message when the user hovers over the field. This is the default.
-		/// Ext.tip.QuickTipManager.init must have been called for this setting to work.
-		/// - title - Display the message in a default browser title attribute popup.
-		/// under Add a block div beneath the field containing the error message.
-		/// - side - Add an error icon to the right of the field, displaying the message in a popup on hover.
-		/// - none - Don't display any error message. This might be useful if you are implementing custom error display.
-		/// - [element id] - Add the error message directly to the innerHTML of the specified element.
-		/// </summary>
-		public string msgTarget { get; set; }
+        /// <summary>
+        /// The location where the error message text should display. Must be one of the following values:
+        /// - qtip - Display a quick tip containing the message when the user hovers over the field. This is the default.
+        /// Ext.tip.QuickTipManager.init must have been called for this setting to work.
+        /// - title - Display the message in a default browser title attribute popup.
+        /// under Add a block div beneath the field containing the error message.
+        /// - side - Add an error icon to the right of the field, displaying the message in a popup on hover.
+        /// - none - Don't display any error message. This might be useful if you are implementing custom error display.
+        /// - [element id] - Add the error message directly to the innerHTML of the specified element.
+        /// </summary>
+        public string msgTarget { get; set; }
 
-		/// <summary>
-		/// /// true to disable displaying any error message set on this object. Defaults to false.
-		/// </summary>		
-		public bool preventMark { get; set; }
-	}
+        /// <summary>
+        /// /// true to disable displaying any error message set on this object. Defaults to false.
+        /// </summary>		
+        public bool preventMark { get; set; }
+    }
 
-	/// <summary>
-	/// Restore container level.
-	/// </summary>
-	public class DextopFormRestoreContainerLevelAttribute : DextopFormContainerAttribute
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="DextopFormRestoreContainerLevelAttribute"/> class.
-		/// </summary>
-		/// <param name="level">The level.</param>
-		public DextopFormRestoreContainerLevelAttribute(int level)
-		{ 
-			Level = level; 
-		}
+    /// <summary>
+    /// Restore container level.
+    /// </summary>
+    public class DextopFormRestoreContainerLevelAttribute : DextopFormContainerAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DextopFormRestoreContainerLevelAttribute"/> class.
+        /// </summary>
+        /// <param name="level">The level.</param>
+        public DextopFormRestoreContainerLevelAttribute(int level)
+        {
+            Level = level;
+        }
 
-		/// <summary>
-		/// Converts this attribute to a Dextop container.
-		/// </summary>
-		/// <param name="memberName">Name of the member.</param>
-		/// <param name="memberType">Type of the member.</param>		
-		/// <returns></returns>
-		public override DextopFormContainer ToContainer(string memberName, Type memberType)
-		{
-			var res = base.ToContainer(memberName, memberType);
-			res.Hollow = true;
-			return res;
-		}
-	}
+        /// <summary>
+        /// Converts this attribute to a Dextop container.
+        /// </summary>
+        /// <param name="memberName">Name of the member.</param>
+        /// <param name="memberType">Type of the member.</param>		
+        /// <returns></returns>
+        public override DextopFormContainer ToContainer(string memberName, Type memberType)
+        {
+            var res = base.ToContainer(memberName, memberType);
+            res.Hollow = true;
+            return res;
+        }
+    }
 }

--- a/Libraries/Codaxy.Dextop/Codaxy.Dextop/Forms/DextopForm.Container.cs
+++ b/Libraries/Codaxy.Dextop/Codaxy.Dextop/Forms/DextopForm.Container.cs
@@ -6,46 +6,52 @@ using Codaxy.Dextop.Tools;
 
 namespace Codaxy.Dextop.Forms
 {
-	/// <summary>
-	/// Base class for Ext containers (panels, tabs, etc.)
-	/// </summary>
+    /// <summary>
+    /// Base class for Ext containers (panels, tabs, etc.)
+    /// </summary>
     public class DextopFormContainer : DextopFormObject
     {
-		/// <summary>
-		/// An itemId can be used as an alternative way to get a reference to a component when no object reference is available.
-		/// </summary>
+        /// <summary>
+        /// An itemId can be used as an alternative way to get a reference to a component when no object reference is available.
+        /// </summary>
         public String itemId { get; set; }
 
         internal int Level { get; set; }
-		internal bool Hollow { get; set; }
+        internal bool Hollow { get; set; }
 
-		/// <summary>
-		/// Gets the name of the item.
-		/// </summary>
+        /// <summary>
+        /// Gets the name of the item.
+        /// </summary>
         public override string ItemName
         {
             get { return itemId; }
         }
 
-		/// <summary>
-		/// Write the properties from the bag to the writer. This method can be overrided for advanced scenarios.
-		/// </summary>
-		/// <param name="jw">The writer.</param>
+        /// <summary>
+        /// Write the properties from the bag to the writer. This method can be overrided for advanced scenarios.
+        /// </summary>
+        /// <param name="jw">The writer.</param>
         protected override void WriteProperties(DextopJsWriter jw)
         {
             jw.DefaultProperty("itemId", itemId);
             jw.DefaultProperty("xtype", xtype);
             if (itemId != null)
+            {
                 jw.AddLocalizationProperty("title", title, itemId + "TitleText");
+                jw.AddLocalizationProperty("fieldLabel", fieldLabel, itemId + "FieldLabelText");
+            }
             else
+            {
                 jw.DefaultProperty("title", title);
+                jw.DefaultProperty("fieldLabel", fieldLabel);
+            }
             if (layout != null)
             {
                 jw.AddProperty("layout", layout);
             }
             jw.DefaultRawProperty("defaults", defaults);
             jw.DefaultRawProperty("fieldDefaults", fieldDefaults);
-            jw.DefaultProperty("margins", margins);
+            jw.DefaultProperty("margin", margin);
             jw.DefaultProperty("style", style);
             jw.DefaultProperty("bodyStyle", bodyStyle);
             jw.DefaultProperty("border", border);
@@ -67,10 +73,10 @@ namespace Codaxy.Dextop.Forms
         /// </summary>
         public string[] AppendItems { get; set; }
 
-		/// <summary>
-		/// Writes the children to the items property.
-		/// </summary>
-		/// <param name="jw">The jw.</param>
+        /// <summary>
+        /// Writes the children to the items property.
+        /// </summary>
+        /// <param name="jw">The jw.</param>
         protected override void WriteItems(DextopJsWriter jw)
         {
             if (Items.Count > 0)
@@ -111,55 +117,60 @@ namespace Codaxy.Dextop.Forms
             }
         }
 
-		/// <summary>
-		/// Gets or sets the xtype.
-		/// </summary>		
+        /// <summary>
+        /// Gets or sets the xtype.
+        /// </summary>		
         public string xtype { get; set; }
-		
-		/// <summary>
-		/// Gets or sets the title.
-		/// </summary>
+
+        /// <summary>
+        /// Gets or sets the title.
+        /// </summary>
         public string title { get; set; }
-		
-		/// <summary>
-		/// Gets or sets the layout.
-		/// </summary>
+
+        /// <summary>
+        /// Gets or sets the fieldLabel.
+        /// </summary>
+        public string fieldLabel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the layout.
+        /// </summary>
         public string layout { get; set; }
-		
-		/// <summary>
-		/// Gets or sets the margins.
-		/// </summary>
-        public string margins { get; set; }
-		
-		/// <summary>
-		/// Gets or sets the field defaults.
-		/// </summary>
+
+        /// <summary>
+        /// Gets or sets the margins.
+        /// </summary>
+        public string margin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the field defaults.
+        /// </summary>
         public string fieldDefaults { get; set; }
-		
-		/// <summary>
-		/// Gets or sets the defaults.
-		/// </summary>
+
+        /// <summary>
+        /// Gets or sets the defaults.
+        /// </summary>
         public string defaults { get; set; }
-		
-		/// <summary>
-		/// Gets or sets the style.
-		/// </summary>
+
+        /// <summary>
+        /// Gets or sets the style.
+        /// </summary>
         public string style { get; set; }
-		
-		/// <summary>
-		/// Gets or sets the body style.
-		/// </summary>
+
+        /// <summary>
+        /// Gets or sets the body style.
+        /// </summary>
         public string bodyStyle { get; set; }
 
-		/// <summary>
-		/// Gets or sets the border.
-		/// </summary>		
+        /// <summary>
+        /// Gets or sets the border.
+        /// </summary>		
         public bool? border { get; set; }
 
-		/// <summary>
-		/// Gets or sets the autoHeight.
-		/// </summary>		
-		public bool autoHeight { get; set; }
+        /// <summary>
+        /// Gets or sets the autoHeight.
+        /// </summary>		
+        public bool autoHeight { get; set; }
 
         /// <summary>
         /// This value is what tells the layout how an item should be anchored to the container. 
@@ -180,5 +191,5 @@ namespace Codaxy.Dextop.Forms
         /// Width of the field.
         /// </summary>
         public int? width { get; set; }
-	}
+    }
 }

--- a/NuGet/Codaxy.Dextop/Codaxy.Dextop.nuspec
+++ b/NuGet/Codaxy.Dextop/Codaxy.Dextop.nuspec
@@ -3,7 +3,7 @@
   <metadata schemaVersion="2">
     <id>Codaxy.Dextop.5</id>    
     <title>Dextop RIA Framework (Full) - Ext JS 5</title>
-    <version>5.1.0.6</version>
+    <version>5.1.0.7</version>
     <authors>Codaxy</authors>
     <description>Dextop Rich Internet Application Framework (Full)</description>
   <projectUrl>https://github.com/codaxy/dextop</projectUrl>


### PR DESCRIPTION
CheckBoxGroup uses fieldLabel instead of title, which failed to localize
eventually.